### PR TITLE
Hide inbox overview until after login

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SMS Sync &mdash; Secure Login</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+    <script src="script.js" defer></script>
+  </head>
+  <body>
+    <main class="app-shell">
+      <section
+        class="view view--login active"
+        id="loginView"
+        aria-hidden="false"
+      >
+        <div class="login-layout">
+          <div class="phone-preview" aria-hidden="true">
+            <div class="phone-preview__inner">
+              <div class="phone-status-bar">
+                <span class="phone-time">9:41</span>
+                <div class="phone-status-icons">
+                  <span class="dot"></span>
+                  <span class="dot"></span>
+                  <span class="dot"></span>
+                </div>
+              </div>
+              <div class="phone-thread">
+                <div class="bubble bubble--incoming">
+                  <h3>SMS Sync</h3>
+                  <p>
+                    Welcome back! Use your secure credentials to keep your customer
+                    conversations in perfect sync.
+                  </p>
+                  <time>Just now</time>
+                </div>
+                <div class="bubble bubble--outgoing">
+                  <p>
+                    On it. Let me grab my inbox so I never miss another message.
+                  </p>
+                  <time>09:39</time>
+                </div>
+                <div class="bubble bubble--incoming">
+                  <p>
+                    Great! Tap the sign-in button and we will reconnect your SMS
+                    workspace instantly.
+                  </p>
+                  <time>09:39</time>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="login-card">
+            <div class="login-card__header">
+              <span class="pill">SMS Sync</span>
+              <h1>Sign in to your inbox</h1>
+              <p>
+                Manage conversations, track replies, and collaborate with your
+                team from one secure hub.
+              </p>
+            </div>
+            <form class="form" id="loginForm" novalidate>
+              <div class="form__field">
+                <label for="email">Email address</label>
+                <input
+                  type="email"
+                  id="email"
+                  name="email"
+                  inputmode="email"
+                  autocomplete="username"
+                  placeholder="you@example.com"
+                  required
+                />
+              </div>
+              <div class="form__field">
+                <label for="password">Password</label>
+                <input
+                  type="password"
+                  id="password"
+                  name="password"
+                  autocomplete="current-password"
+                  placeholder="Enter your password"
+                  required
+                  minlength="6"
+                />
+              </div>
+              <div class="form__extras">
+                <label class="checkbox">
+                  <input type="checkbox" id="remember" name="remember" />
+                  <span>Remember me next time</span>
+                </label>
+                <a class="subtle-link" href="#" aria-disabled="true"
+                  >Need help?</a
+                >
+              </div>
+              <button type="submit" class="button button--primary">
+                Sign in
+              </button>
+              <p class="form__hint">
+                Demo credentials: <strong>isubrat@icloud.com</strong> &middot;
+                <strong>subrat@1234</strong>
+              </p>
+            </form>
+          </div>
+        </div>
+      </section>
+      <section class="view view--inbox" id="inboxView" aria-hidden="true">
+        <header class="inbox-header">
+          <div class="inbox-header__info">
+            <div class="badge">Live</div>
+            <div>
+              <h2>Inbox overview</h2>
+              <p>
+                You are connected as <strong id="userEmail">&nbsp;</strong>
+              </p>
+            </div>
+          </div>
+          <button type="button" id="logoutButton" class="button button--ghost">
+            Log out
+          </button>
+        </header>
+        <section class="chat-window" aria-live="polite">
+          <div class="chat-thread" id="chatThread">
+            <div class="bubble bubble--incoming">
+              <h3>Lisa</h3>
+              <p>
+                Hey! Thanks for following up so quickly. The delivery is on time
+                for tomorrow, right?
+              </p>
+              <time>09:12</time>
+            </div>
+            <div class="bubble bubble--outgoing">
+              <p>Absolutely. Driver picks it up at 7am and you&apos;ll get an ETA.</p>
+              <time>09:13</time>
+            </div>
+            <div class="bubble bubble--incoming">
+              <p>
+                Perfect! Could you also confirm the invoice was sent to my email?
+              </p>
+              <time>09:14</time>
+            </div>
+          </div>
+        </section>
+        <form class="composer" id="messageForm" autocomplete="off">
+          <input
+            type="text"
+            id="messageInput"
+            name="message"
+            placeholder="Type a reply..."
+            aria-label="Type a reply"
+          />
+          <button type="submit" class="button button--primary">Send</button>
+        </form>
+      </section>
+    </main>
+    <div class="toast" id="feedback" role="status" aria-live="polite"></div>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,172 @@
+(() => {
+  const VALID_EMAIL = 'isubrat@icloud.com';
+  const VALID_PASSWORD = 'subrat@1234';
+  const STORAGE_KEY = 'smsSyncCredentials';
+
+  const loginView = document.getElementById('loginView');
+  const inboxView = document.getElementById('inboxView');
+  const loginForm = document.getElementById('loginForm');
+  const emailInput = document.getElementById('email');
+  const passwordInput = document.getElementById('password');
+  const rememberCheckbox = document.getElementById('remember');
+  const userEmailDisplay = document.getElementById('userEmail');
+  const feedback = document.getElementById('feedback');
+  const logoutButton = document.getElementById('logoutButton');
+  const chatThread = document.getElementById('chatThread');
+  const messageForm = document.getElementById('messageForm');
+  const messageInput = document.getElementById('messageInput');
+
+  let toastTimeout;
+
+  const storedCredentials = getStoredCredentials();
+  if (storedCredentials) {
+    emailInput.value = storedCredentials.email;
+    passwordInput.value = storedCredentials.password;
+    rememberCheckbox.checked = true;
+    showInbox(storedCredentials.email, true);
+  } else {
+    window.setTimeout(() => emailInput.focus(), 150);
+  }
+
+  loginForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const email = emailInput.value.trim();
+    const password = passwordInput.value;
+
+    if (authenticate(email, password)) {
+      if (rememberCheckbox.checked) {
+        setStoredCredentials({ email, password });
+      } else {
+        clearStoredCredentials();
+      }
+      showInbox(email, false);
+    } else {
+      showToast('Incorrect email or password. Try again.', 'error');
+      triggerShake();
+    }
+  });
+
+  logoutButton.addEventListener('click', () => {
+    clearStoredCredentials();
+    passwordInput.value = '';
+    rememberCheckbox.checked = false;
+    showLogin();
+    showToast('You have been logged out safely.', 'info');
+  });
+
+  if (messageForm) {
+    messageForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const text = messageInput.value.trim();
+      if (!text) return;
+
+      appendMessage(text, 'outgoing');
+      messageInput.value = '';
+      messageInput.focus();
+
+      setTimeout(() => {
+        appendMessage('Received loud and clear! We will take it from here.', 'incoming');
+      }, 900);
+    });
+  }
+
+  function authenticate(email, password) {
+    return email === VALID_EMAIL && password === VALID_PASSWORD;
+  }
+
+  function showInbox(email, isAutoLogin) {
+    loginView.classList.remove('active');
+    loginView.setAttribute('aria-hidden', 'true');
+    inboxView.classList.add('active');
+    inboxView.setAttribute('aria-hidden', 'false');
+    userEmailDisplay.textContent = email;
+    if (messageInput) {
+      messageInput.focus();
+    }
+
+    const message = isAutoLogin
+      ? 'Welcome back! You were signed in automatically.'
+      : 'Login successful. Conversations synced.';
+    showToast(message, 'success');
+  }
+
+  function showLogin() {
+    inboxView.classList.remove('active');
+    inboxView.setAttribute('aria-hidden', 'true');
+    loginView.classList.add('active');
+    loginView.setAttribute('aria-hidden', 'false');
+    emailInput.focus();
+  }
+
+  function triggerShake() {
+    loginForm.classList.remove('shake');
+    // Force reflow so the animation can restart
+    void loginForm.offsetWidth;
+    loginForm.classList.add('shake');
+  }
+
+  function showToast(message, type) {
+    feedback.textContent = message;
+    feedback.dataset.type = type;
+    feedback.classList.add('visible');
+
+    clearTimeout(toastTimeout);
+    toastTimeout = setTimeout(() => {
+      feedback.classList.remove('visible');
+    }, 4000);
+  }
+
+  function appendMessage(text, variant) {
+    if (!chatThread) return;
+    const bubble = document.createElement('div');
+    bubble.className = `bubble bubble--${variant}`;
+
+    const paragraph = document.createElement('p');
+    paragraph.innerHTML = escapeHtml(text);
+
+    const time = document.createElement('time');
+    time.textContent = new Date().toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+
+    bubble.append(paragraph, time);
+    chatThread.appendChild(bubble);
+    chatThread.scrollTop = chatThread.scrollHeight;
+  }
+
+  function escapeHtml(str) {
+    const temp = document.createElement('div');
+    temp.textContent = str;
+    return temp.innerHTML;
+  }
+
+  function setStoredCredentials(credentials) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(credentials));
+  }
+
+  function getStoredCredentials() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      if (
+        parsed &&
+        typeof parsed.email === 'string' &&
+        typeof parsed.password === 'string'
+      ) {
+        if (authenticate(parsed.email, parsed.password)) {
+          return parsed;
+        }
+      }
+      return null;
+    } catch (error) {
+      console.error('Unable to access stored credentials', error);
+      return null;
+    }
+  }
+
+  function clearStoredCredentials() {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+})();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,540 @@
+:root {
+  color-scheme: light;
+  --bg-gradient: radial-gradient(circle at top left, #6471f2, #182848 55%);
+  --glass: rgba(255, 255, 255, 0.93);
+  --primary: #4a6cf7;
+  --primary-dark: #3a57d0;
+  --accent: #ff9f68;
+  --incoming: #f8fafc;
+  --incoming-border: rgba(15, 23, 42, 0.08);
+  --outgoing: linear-gradient(120deg, #4a6cf7, #7f9bff);
+  --text: #0f172a;
+  --muted: #475569;
+  --border: rgba(148, 163, 184, 0.35);
+  --shadow: 0 30px 80px rgba(15, 23, 42, 0.35);
+  --radius-large: 32px;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+*::selection {
+  background: rgba(74, 108, 247, 0.16);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  background: var(--bg-gradient);
+  color: var(--text);
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at 20% -10%, rgba(255, 255, 255, 0.45),
+      transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(125, 211, 252, 0.35), transparent 60%),
+    radial-gradient(circle at 50% 110%, rgba(241, 244, 255, 0.18), transparent 70%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.app-shell {
+  position: relative;
+  z-index: 1;
+  width: min(100%, 1100px);
+}
+
+.view {
+  display: none;
+  background: var(--glass);
+  border-radius: var(--radius-large);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(14px);
+  padding: clamp(1.75rem, 4vw, 3.25rem);
+}
+
+.view.active {
+  display: block;
+}
+
+.login-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+  gap: clamp(1.75rem, 5vw, 3rem);
+  align-items: center;
+}
+
+.phone-preview {
+  position: relative;
+  width: min(100%, 360px);
+  margin-inline: auto;
+  padding: 1rem;
+  border-radius: 36px;
+  background: linear-gradient(140deg, rgba(15, 23, 42, 0.85), rgba(15, 23, 42, 0.6));
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.4);
+}
+
+.phone-preview::after {
+  content: '';
+  position: absolute;
+  inset: 12px;
+  border-radius: 30px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  pointer-events: none;
+}
+
+.phone-preview__inner {
+  position: relative;
+  border-radius: 26px;
+  padding: 1.4rem 1.4rem 1.8rem;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.95), rgba(30, 41, 59, 0.75));
+  color: #f8fafc;
+  overflow: hidden;
+  min-height: 460px;
+}
+
+.phone-status-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  opacity: 0.7;
+  font-size: 0.85rem;
+}
+
+.phone-status-icons {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.phone-status-icons .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.8;
+}
+
+.phone-thread {
+  display: flex;
+  flex-direction: column;
+  gap: 1.15rem;
+  margin-top: 2rem;
+}
+
+.bubble {
+  position: relative;
+  max-width: 80%;
+  padding: 0.9rem 1.1rem;
+  border-radius: 22px;
+  background: var(--incoming);
+  border: 1px solid var(--incoming-border);
+  color: var(--text);
+  box-shadow: 0 18px 30px rgba(15, 23, 42, 0.08);
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.96rem;
+  line-height: 1.45;
+}
+
+.bubble h3 {
+  margin: 0;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.bubble--incoming {
+  align-self: flex-start;
+  border-bottom-left-radius: 6px;
+}
+
+.bubble--outgoing {
+  align-self: flex-end;
+  background: var(--outgoing);
+  color: #f8fafc;
+  border-bottom-right-radius: 6px;
+  border: none;
+  box-shadow: 0 20px 32px rgba(74, 108, 247, 0.3);
+}
+
+.bubble time {
+  font-size: 0.78rem;
+  opacity: 0.6;
+  align-self: flex-end;
+}
+
+.login-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.login-card__header h1 {
+  margin-block: 0.35rem 0.75rem;
+  font-size: clamp(1.85rem, 4vw, 2.4rem);
+  line-height: 1.2;
+}
+
+.login-card__header p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(74, 108, 247, 0.12);
+  color: var(--primary);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.form__field label {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.form__field input {
+  width: 100%;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: rgba(248, 250, 252, 0.8);
+  padding: 0.95rem 1.1rem;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form__field input:focus {
+  outline: none;
+  border-color: rgba(74, 108, 247, 0.6);
+  box-shadow: 0 0 0 4px rgba(74, 108, 247, 0.12);
+}
+
+.form__extras {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.95rem;
+}
+
+.checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  cursor: pointer;
+  color: var(--muted);
+}
+
+.checkbox input {
+  width: 18px;
+  height: 18px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  appearance: none;
+  position: relative;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.checkbox input:checked {
+  background: var(--primary);
+  border-color: var(--primary);
+}
+
+.checkbox input:checked::after {
+  content: '';
+  position: absolute;
+  inset: 4px;
+  border-radius: 4px;
+  background: white;
+}
+
+.subtle-link {
+  color: var(--muted);
+  text-decoration: none;
+  pointer-events: none;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  font-weight: 600;
+  font-size: 1rem;
+  border-radius: 18px;
+  border: none;
+  cursor: pointer;
+  padding: 0.95rem 1.4rem;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.button--primary {
+  background: linear-gradient(135deg, var(--primary), #8090ff);
+  color: white;
+  box-shadow: 0 20px 40px rgba(74, 108, 247, 0.25);
+}
+
+.button--primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 24px 45px rgba(74, 108, 247, 0.28);
+}
+
+.button--primary:active {
+  transform: translateY(0);
+}
+
+.button--ghost {
+  background: rgba(74, 108, 247, 0.1);
+  color: var(--primary);
+  border: 1px solid rgba(74, 108, 247, 0.25);
+}
+
+.button--ghost:hover {
+  background: rgba(74, 108, 247, 0.18);
+}
+
+.form__hint {
+  font-size: 0.9rem;
+  color: var(--muted);
+  text-align: center;
+}
+
+.view--inbox {
+  flex-direction: column;
+  gap: 1.75rem;
+  min-height: 540px;
+}
+
+.view--inbox.active {
+  display: flex;
+}
+
+.inbox-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 1rem 1.35rem;
+  border-radius: 20px;
+  background: rgba(15, 23, 42, 0.04);
+}
+
+.inbox-header__info {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.inbox-header h2 {
+  margin: 0;
+  font-size: 1.45rem;
+}
+
+.inbox-header p {
+  margin: 0.25rem 0 0;
+  color: var(--muted);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.3rem 0.75rem;
+  border-radius: 12px;
+  background: rgba(74, 108, 247, 0.15);
+  color: var(--primary);
+  font-weight: 600;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.chat-window {
+  flex: 1;
+  background: linear-gradient(160deg, rgba(248, 250, 252, 0.95), #ffffff 85%);
+  border-radius: 26px;
+  padding: clamp(1.2rem, 3vw, 1.8rem);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.15);
+}
+
+.chat-thread {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding-right: 0.3rem;
+}
+
+.chat-thread::-webkit-scrollbar {
+  width: 6px;
+}
+
+.chat-thread::-webkit-scrollbar-thumb {
+  background: rgba(100, 116, 139, 0.25);
+  border-radius: 999px;
+}
+
+.composer {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 0.65rem 0.65rem 1.1rem;
+  border-radius: 999px;
+  background: white;
+  box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
+}
+
+.composer input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  font-size: 1rem;
+  color: var(--text);
+  font-family: inherit;
+}
+
+.composer input:focus {
+  outline: none;
+}
+
+.composer .button {
+  min-width: 120px;
+}
+
+.toast {
+  position: fixed;
+  left: 50%;
+  bottom: 2.5rem;
+  transform: translate(-50%, 25px);
+  padding: 0.85rem 1.6rem;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.92);
+  color: white;
+  font-weight: 500;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.45);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  z-index: 10;
+}
+
+.toast.visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.toast[data-type='success'] {
+  background: rgba(34, 197, 94, 0.95);
+}
+
+.toast[data-type='error'] {
+  background: rgba(239, 68, 68, 0.95);
+}
+
+.toast[data-type='info'] {
+  background: rgba(15, 23, 42, 0.92);
+}
+
+.form.shake {
+  animation: shake 0.45s ease;
+}
+
+@keyframes shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  20%,
+  60% {
+    transform: translateX(-6px);
+  }
+  40%,
+  80% {
+    transform: translateX(6px);
+  }
+}
+
+@media (max-width: 900px) {
+  .view {
+    border-radius: 24px;
+  }
+  .login-layout {
+    grid-template-columns: 1fr;
+  }
+  .phone-preview {
+    order: 2;
+  }
+  .login-card {
+    order: 1;
+  }
+  .composer .button {
+    min-width: 100px;
+  }
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 1.5rem;
+  }
+  .view {
+    padding: 1.5rem;
+  }
+  .inbox-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .composer {
+    flex-direction: column;
+    align-items: stretch;
+    border-radius: 22px;
+    gap: 0.5rem;
+  }
+  .composer .button {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- prevent the inbox view from inheriting flex display when it is not active
- ensure the inbox becomes visible only after login activates the view

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cce48c212c832db1a330638fa3ba96