### PR TITLE
Stop showing inbox overview before login

### DIFF
--- a/script.js
+++ b/script.js
@@ -23,10 +23,9 @@
     emailInput.value = storedCredentials.email;
     passwordInput.value = storedCredentials.password;
     rememberCheckbox.checked = true;
-    showInbox(storedCredentials.email, true);
-  } else {
-    window.setTimeout(() => emailInput.focus(), 150);
   }
+
+  window.setTimeout(() => emailInput.focus(), 150);
 
   loginForm.addEventListener('submit', (event) => {
     event.preventDefault();


### PR DESCRIPTION
## Summary
- stop the inbox view from auto-activating when stored credentials are present so the login screen remains visible
- leave the login focus behavior in place so users can begin typing immediately

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ccfe16e1ac832d8e3829d7af433e8a