### PR TITLE
Hide inbox view until login

### DIFF
--- a/script.js
+++ b/script.js
@@ -23,10 +23,9 @@
     emailInput.value = storedCredentials.email;
     passwordInput.value = storedCredentials.password;
     rememberCheckbox.checked = true;
-    showInbox(storedCredentials.email, true);
-  } else {
-    window.setTimeout(() => emailInput.focus(), 150);
   }
+
+  window.setTimeout(() => emailInput.focus(), 150);
 
   loginForm.addEventListener('submit', (event) => {
     event.preventDefault();

--- a/styles.css
+++ b/styles.css
@@ -330,10 +330,14 @@ body::before {
 }
 
 .view--inbox {
-  display: flex;
+  display: none;
   flex-direction: column;
   gap: 1.75rem;
   min-height: 540px;
+}
+
+.view--inbox.active {
+  display: flex;
 }
 
 .inbox-header {


### PR DESCRIPTION
## Summary
- prevent the inbox pane from displaying until the inbox view receives the active class
- keep the flex layout applied when the inbox is active so the layout remains unchanged after login

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ccfe16e1ac832d8e3829d7af433e8a